### PR TITLE
Fixed application delegate deprecated method

### DIFF
--- a/00-Login/ios/Auth0Samples/AppDelegate.m
+++ b/00-Login/ios/Auth0Samples/AppDelegate.m
@@ -14,11 +14,10 @@
 
 @implementation AppDelegate
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:app openURL:url options:options];
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions


### PR DESCRIPTION
## Changes

Replaced a deprecated `UIApplicationDelegate` method call. 

## References

- [application(_:open:options:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application)
- Related to https://github.com/auth0/docs/pull/8721, but they don't have to be merged together.
