### PR TITLE
Fix iOS bundle identifier

### DIFF
--- a/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
+++ b/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
@@ -622,7 +622,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.ritazerrizuela.ReactNativeDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0samples;
 				PRODUCT_NAME = Auth0Samples;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Samples-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -646,7 +646,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.ritazerrizuela.ReactNativeDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0samples;
 				PRODUCT_NAME = Auth0Samples;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Samples-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Wasn't able to get this project running on iOS following the provided instructions. Managed to track down the issue to the bundle ID changing in PR #46. Reverting it back to `com.auth0samples` fixed the issue.

Before output
<img src="https://user-images.githubusercontent.com/4096877/119702968-ea03cc80-be0a-11eb-89b0-1c6b6f54d559.png" width=200 />

Before warning
<img src="https://user-images.githubusercontent.com/4096877/119702999-f1c37100-be0a-11eb-8f6b-c09f596444d8.png" width=200 />

After
<img src="https://user-images.githubusercontent.com/4096877/119703009-f5ef8e80-be0a-11eb-8147-bf1efeab1a96.png" width=200 />

