### PR TITLE
Update app with SDK v2.9.0 [SDK-2621]

### DIFF
--- a/00-Login/android/app/build.gradle
+++ b/00-Login/android/app/build.gradle
@@ -136,6 +136,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        manifestPlaceholders = [auth0Domain: "YOUR_AUTH0_DOMAIN",
+                                auth0Scheme: "${applicationId}"]
     }
     splits {
         abi {

--- a/00-Login/android/app/src/main/AndroidManifest.xml
+++ b/00-Login/android/app/src/main/AndroidManifest.xml
@@ -13,21 +13,11 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:launchMode="singleTask"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data
-                android:host="{DOMAIN}"
-                android:pathPrefix="/android/${applicationId}/callback"
-                android:scheme="${applicationId}" />
         </intent-filter>
       </activity>
     </application>

--- a/00-Login/android/build.gradle
+++ b/00-Login/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:4.2.0')
+        classpath('com.android.tools.build:gradle:4.2.1')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/00-Login/package.json
+++ b/00-Login/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "17.0.1",
     "react-native": "0.64.0",
-    "react-native-auth0": "2.8.3"
+    "react-native-auth0": "2.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
This PR updates the RN sample app to accommodate the [breaking changes](https://github.com/auth0/react-native-auth0/releases/tag/v2.9.0) in the version `v2.9.0` of the Auth0 react native SDK.

Related: https://github.com/auth0/react-native-auth0/pull/350