### PR TITLE
Bump platform to 12.4

### DIFF
--- a/00-Login/ios/Podfile
+++ b/00-Login/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '11.0'
+platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'Auth0Samples' do


### PR DESCRIPTION
I cloned and installed 00-Login. 

On `cd ios && pod install`:

```
$ pod install
[Codegen] Generating ./build/generated/ios/React-Codegen.podspec.json
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
[Codegen] Found FBReactNativeSpec
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
Fetching podspec for `boost` from `../node_modules/react-native/third-party-podspecs/boost.podspec`
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
[!] CocoaPods could not find compatible versions for pod "React-RCTLinking":
  In Podfile:
    React-RCTLinking (from `../node_modules/react-native/Libraries/LinkingIOS`)

Specs satisfying the `React-RCTLinking (from `../node_modules/react-native/Libraries/LinkingIOS`)` dependency were found, but they required a higher minimum deployment target.
```

The podspec for React-RCTLinking says:

```
  s.platforms              = { :ios => "12.4" }
```

It seems RN itself is at 12.4 now, too.