### PR TITLE
Update SDK to v2.13.3

### DIFF
--- a/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
+++ b/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -868,6 +869,7 @@
 					"\"$(inherited)",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/00-Login/ios/Podfile
+++ b/00-Login/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '11.0'
+platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'Auth0Samples' do

--- a/00-Login/package.json
+++ b/00-Login/package.json
@@ -9,9 +9,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "17.0.2",
-    "react-native": "0.69.0",
-    "react-native-auth0": "^2.13.0"
+    "react": "18.0.0",
+    "react-native": "0.69.1",
+    "react-native-auth0": "^2.13.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -21,7 +21,7 @@
     "eslint": "^7.32.0",
     "jest": "^28.1.0",
     "metro-react-native-babel-preset": "^0.71.0",
-    "react-test-renderer": "17.0.2"
+    "react-test-renderer": "18.0.0"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
This PR updates the react-native-auth0 SDK to v2.13.3, using React Native 0.69.1, and integrates the changes in https://github.com/auth0-samples/auth0-react-native-sample/pull/66.

<img width="954" alt="Screen Shot 2022-07-06 at 12 51 49" src="https://user-images.githubusercontent.com/5055789/177592434-c26ed0ad-73b8-4e29-843a-7de97854f6a0.png">

<img width="988" alt="Screen Shot 2022-07-06 at 13 00 17" src="https://user-images.githubusercontent.com/5055789/177593899-58eec572-42bb-47e0-9d30-f3f2d355b79b.png">