### PR TITLE
Use correct placeholder in build.gradle

### DIFF
--- a/00-Login/android/app/build.gradle
+++ b/00-Login/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-        manifestPlaceholders = [auth0Domain: "YOUR_AUTH0_DOMAIN", auth0Scheme: "${applicationId}"]
+        manifestPlaceholders = [auth0Domain: "{DOMAIN}", auth0Scheme: "${applicationId}"]
     }
 
     splits {


### PR DESCRIPTION
I'm not sure yet if the file is required to have a `.example` extension, base on [this code](https://github.com/auth0/auth0-package-creator/blob/master/lib/v2/processor.js#L87-L118) it might not need one. Let's see if this works, and will iterate if need be.

It's not making it any worse, at least, as it doesn't currently work when downloading through the quickstart anyway.
