### PR TITLE
Fix Swift Core library not found

### DIFF
--- a/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
+++ b/00-Login/ios/Auth0Samples.xcodeproj/project.pbxproj
@@ -616,7 +616,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 22U9KJ5PK6;
 				INFOPLIST_FILE = Auth0Samples/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -640,7 +640,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 22U9KJ5PK6;
 				INFOPLIST_FILE = Auth0Samples/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
While implementing Credentials Manager for Swift, We figured that not having the Swift Core library causes the app to crash when external dependencies with this library requirement are added. So we have now added this to the search path