### PR TITLE
Make expo use scheme

### DIFF
--- a/00-Login-Expo/App.js
+++ b/00-Login-Expo/App.js
@@ -4,13 +4,14 @@ import {useAuth0, Auth0Provider} from 'react-native-auth0';
 import config from './auth0-configuration';
 
 const Home = () => {
-  const {authorize, clearSession, user, getCredentials} = useAuth0();
+  const {authorize, clearSession, user, error, getCredentials} = useAuth0();
 
   const onLogin = async () => {
     try {
-      await authorize({scope: 'openid profile email'});
-      const {accessToken} = await getCredentials();
-      Alert.alert('AccessToken: ' + accessToken);
+      await authorize({scope: 'openid profile email'}, {customScheme: 'auth0.com.auth0samples'});
+      let credentials = await getCredentials();
+      console.log(credentials)
+      Alert.alert('AccessToken: ' + credentials.accessToken);
     } catch (e) {
       console.log(e);
     }
@@ -20,7 +21,7 @@ const Home = () => {
 
   const onLogout = async () => {
     try {
-      await clearSession();
+      await clearSession({customScheme: 'auth0.com.auth0samples'});
     } catch (e) {
       console.log('Log out cancelled');
     }
@@ -31,6 +32,7 @@ const Home = () => {
       <Text style={styles.header}> Auth0Sample - Login </Text>
       {user && <Text>You are logged in as {user.name}</Text>}
       {!user && <Text>You are not logged in</Text>}
+      {error && <Text>{error.message}</Text>}
       <Button
         onPress={loggedIn ? onLogout : onLogin}
         title={loggedIn ? 'Log Out' : 'Log In'}

--- a/00-Login-Expo/App.js
+++ b/00-Login-Expo/App.js
@@ -10,7 +10,6 @@ const Home = () => {
     try {
       await authorize({scope: 'openid profile email'}, {customScheme: 'auth0.com.auth0samples'});
       let credentials = await getCredentials();
-      console.log(credentials)
       Alert.alert('AccessToken: ' + credentials.accessToken);
     } catch (e) {
       console.log(e);

--- a/00-Login-Expo/app.json
+++ b/00-Login-Expo/app.json
@@ -10,7 +10,8 @@
       [
         "react-native-auth0",
         {
-          "domain": "{DOMAIN}"
+          "domain": "poovamraj.eu.auth0.com",
+          "customScheme": "auth0.com.auth0samples"
         }
       ]
     ],


### PR DESCRIPTION
### Changes

With this documentation change, we are making custom scheme mandatory. This is due to the reason that Expo uses the application ID or bundle identifier we use to as the scheme to open the application. This shows a popup when the login is done successfully and choosing the wrong option could break the application flow.

For this reason we have made custom scheme as mandatory for Expo application and added guidance on how to do it.

This will change in the next major where we will generate the scheme for callback URL with `auth0` prefixed to the package name to avoid clash with Expo

### References

Issues were raised because of this 

https://github.com/auth0/react-native-auth0/issues/582
https://github.com/auth0/react-native-auth0/issues/606

PR in repo - https://github.com/auth0/react-native-auth0/pull/610